### PR TITLE
change dependency style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-# a gem's github dependencies have to be repeated in gemfiles of apps that use
-# this gem
+# dependency inheritance is not handled by bundler for gems that are pulled
+# from github. repeat these dependencies in your gemfile when you use this gem
 gem 'iban-tools', github: 'gapfish/iban-tools'
 gem 'banking_data', github: 'gapfish/banking_data' # dependency of iban-tools
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'iban-tools', github: 'opahk/iban-tools', branch: 'banking_data'
+# a gem's github dependencies have to be repeated in gemfiles of apps that use
+# this gem
+gem 'iban-tools', github: 'gapfish/iban-tools'
+gem 'banking_data', github: 'gapfish/banking_data' # dependency of iban-tools
 
 # Specify your gem's dependencies in iban_validation.gemspec
 gemspec

--- a/iban_validation.gemspec
+++ b/iban_validation.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'activemodel'
-  #gem.add_dependency 'iban-tools'
+  # gem.add_dependency 'iban-tools' # from Github, see Gemfile
+  # gem.add_dependency 'banking_data' # from Github, see Gemfile
+
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'appraisal'

--- a/spec/iban_validation/known_iban_validator_spec.rb
+++ b/spec/iban_validation/known_iban_validator_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 module IbanValidation
   describe KnownIbanValidator do
     begin
-      require 'banking_data'
 
       class KnownModel
         include ActiveModel::Validations
@@ -34,8 +33,6 @@ module IbanValidation
         model = KnownModel.new 'DE15763500000036109724'
         expect(model).to be_valid
       end
-    rescue LoadError
-      pending
     end
   end
 end


### PR DESCRIPTION
I need this for my ruby3 branch, because it indirectly references the banking_data gem, that needed to be updated for ruby3. 
(the dependency chain goes: gapfish mothership -> iban_validation -> iban-tools -> banking_data)
We use now forked repositories instead of the gems, because we couldn't control those properly.

- explanation about inherited dependencies that are unfortunately not automatically pulled by bundler
- add banking_data and iban-tools gem in gemfile and make it mandatory in specs
- remove "require banking_data" as it's required within iban-tools already
